### PR TITLE
Added functionality to skip the first x recipes and then limit response

### DIFF
--- a/apps/mealplanr-api/src/collections/recipe/recipe.controller.ts
+++ b/apps/mealplanr-api/src/collections/recipe/recipe.controller.ts
@@ -64,13 +64,15 @@ export async function getRecipeHandler(req: Request, res: Response) {
 	let recipeId = get(req, 'query.recipeId');
 	let creatorId = get(req, 'query.creatorId');
 	let limit = get(req, 'query.limit');
+	let skip = get(req, 'query.skip');
 	limit = Math.min(Math.max(parseInt(limit), 1), 100);
+	skip = Math.min(Math.max(parseInt(skip), 0), 1000);
 
 	recipeId = recipeId ? { recipeId } : {};
 	creatorId = creatorId ? { creatorId } : {};
 
 	const query = { ...recipeId, ...creatorId };
-	const recipe = await findRecipe(query, limit);
+	const recipe = await findRecipe(query, {limit, skip});
 
 	if (!recipe) {
 		return res.status(404).send('No such recipe exists');

--- a/apps/mealplanr-api/src/collections/recipe/recipe.schema.ts
+++ b/apps/mealplanr-api/src/collections/recipe/recipe.schema.ts
@@ -31,6 +31,7 @@ const query = {
 		recipeId: string(),
 		creatorId: string(),
 		limit: number(),
+		skip: number(),
 	}),
 };
 

--- a/apps/mealplanr-api/src/collections/recipe/recipe.service.ts
+++ b/apps/mealplanr-api/src/collections/recipe/recipe.service.ts
@@ -50,14 +50,16 @@ export async function createRecipe(body: DocumentDefinition<RecipeDocument>) {
  */
 export async function findRecipe(
 	query: FilterQuery<RecipeDocument>,
-	limit = 1,
 	options: QueryOptions = { lean: true }
 ) {
 	try {
 		query = sanitize(query);
 
-		if (isNaN(limit)) limit = 100;
-		return populateRecipe(recipeModel.find(query, {}, options).limit(limit));
+		// Sort the collection to make sure it is the same recipes, that gets served. 
+		// The sort should be done on the client side in the future, but this is a fallback.
+		options = { sort: { _id: 1 }, ...options };
+
+		return populateRecipe(recipeModel.find(query, {}, options));
 	} catch (error) {
 		throw new Error(error as string);
 	}


### PR DESCRIPTION
## Purpose/Approach
<!-- Describe the problem or feature. How does this change address the problem? -->
If one wanted to first get the first 10 recipes in one request, and then the next 10 recipes in a new request, one was not able to do that.

With this fix, one can skip the first x recipes and then get the next y recipes.

## Testing steps to find bugs or errors in added code.
<!-- Add testing steps, you think could cause problems for testers -->
<!-- Make et easy for testers to test the code before reviewing the PR. -->

- [x] Test different combinations of parameters for the REST call.
